### PR TITLE
fix stipe dependencies to 11.2.0 instead of ^11.2.0

### DIFF
--- a/packages/stripe/pubspec.yaml
+++ b/packages/stripe/pubspec.yaml
@@ -21,10 +21,10 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.8.0
-  stripe_android: ^11.2.0
-  stripe_ios: ^11.2.0
-  stripe_platform_interface: ^11.2.0
+  meta: 1.8.0
+  stripe_android: 11.2.0
+  stripe_ios: 11.2.0
+  stripe_platform_interface: 11.2.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
We see CI failing because of the `^` dependency as it pulls in the latest release 11.5.0 that has been published yesterday and has some breaking changes (android kotlin version binary incompatibility, etc.)

Could we please pin 11.2.0 in the meantime until we found a better solution?

Thanks